### PR TITLE
fix: replace pytz with zoneinfo to resolve timezone crashes

### DIFF
--- a/ticktick.py
+++ b/ticktick.py
@@ -1,6 +1,6 @@
 import requests
 import datetime
-import pytz
+from zoneinfo import ZoneInfo
 import logging
 
 from urllib.parse import urlencode
@@ -42,7 +42,7 @@ class TickTickApi:
                 adatetime = datetime.datetime(adate.year, adate.month, adate.day)
                 isAllDay = True
 
-            adatetime = pytz.timezone(atimezone).localize(adatetime)
+            adatetime = adatetime.replace(tzinfo=ZoneInfo('localtime'))
 
             formatted_date = adatetime.strftime("%Y-%m-%dT%H:%M:%S%z")
 


### PR DESCRIPTION
# Fix timezone crash when creating tasks with time

Hey! Thanks for this ULauncher extension.

I ran into a crash when trying to create tasks with times like `tod 23:00`:

```
pytz.exceptions.UnknownTimeZoneError: 'IST'
```

Turns out `pytz.timezone()` doesn't accept timezone abbreviations like `IST`, `EST`, `PST` - it only works with full IANA names like `Asia/Kolkata`.

The fix is simple: use Python 3.9's built-in `zoneinfo` module with `ZoneInfo('localtime')` instead. It reads the system timezone directly, so no string parsing needed.

**Changes:**
- Replaced `import pytz` → `from zoneinfo import ZoneInfo`
- Replaced `pytz.timezone(atimezone).localize(...)` → `datetime.replace(tzinfo=ZoneInfo('localtime'))`

Tested on my machine (IST timezone) and the timestamps come out correct now.

<details>
<summary>Why this was broken for everyone (not just me)</summary>


I did some digging and found that `pytz` doesn't accept ANY abbreviations - not EST, PST, CET, none of them. It only accepts full IANA names like `America/New_York`.

The original code in `parser.py` uses `datetime.astimezone().tzname()` which returns abbreviations (`IST`, `EST`, etc.), not IANA names. Python's datetime module doesn't have a way to get the IANA name directly.

So technically, this was broken for everyone who tried to create a task with a time. Maybe not many people use that feature, or haven't reported it.

Using `ZoneInfo('localtime')` bypasses this entirely - it reads from `/etc/localtime` on Linux systems and just works.

</details>
