### PR TITLE
fix: correct priority mapping to match TickTick API

### DIFF
--- a/main.py
+++ b/main.py
@@ -171,7 +171,7 @@ class KeywordQueryEventListener(EventListener, VariableUpdateListener):
                     desc = self._compile_description(
                         tags, priority, adate, atime, project_name
                     )
-                    priority_dict = {"low": 1, "medium": 2, "high": 3}
+                    priority_dict = {"low": 1, "medium": 3, "high": 5}
 
                     data = {
                         "action": "create",


### PR DESCRIPTION
# Fix priority mapping to match TickTick API

Hey! Found another issue while testing the extension.

When setting task priority with `!high`, `!medium`, or `!low`, the flags in TickTick don't match what's expected:

| Command | Expected | Actual |
|---------|----------|--------|
| `!high` | Red flag | Yellow flag (medium) |
| `!medium` | Yellow flag | No flag |
| `!low` | Blue flag | Blue flag ✓ |

Turns out the TickTick API uses these priority values:
- `0` = None
- `1` = Low
- `3` = Medium
- `5` = High

The code was using `{1, 2, 3}` instead of `{1, 3, 5}`.

<details>
<summary>Reference</summary>

From TickTick's official API docs: https://developer.ticktick.com/api#/openapi?id=create-a-task

> priority: Number, None, Low, Medium, High corresponding values are 0, 1, 3, 5 respectively

</details>
